### PR TITLE
Adds social share links to each blog article

### DIFF
--- a/lib/modules/apostrophe-blog-pages/views/show.html
+++ b/lib/modules/apostrophe-blog-pages/views/show.html
@@ -32,6 +32,20 @@
         }) }}
       </div>
 
+      <h5>Share this post</h5>
+
+      <a href="https://www.facebook.com/sharer/sharer.php?u=https://quodl-site.herokuapp.com{{data.page.slug + '/' + data.piece.slug}}" target="_blank">
+        Facebook
+      </a>
+
+      <a href="https://www.linkedin.com/cws/share?url=https://quodl-site.herokuapp.com{{data.page.slug + '/' + data.piece.slug}}" target="_blank">
+        Linkedin
+      </a>
+
+      <a href="http://twitter.com/share?text={{ data.piece.title }}&url=https://quodl-site.herokuapp.com{{data.page.slug + '/' + data.piece.slug}}&hashtags=quodl" target="_blank">
+        Twitter
+      </a>
+
       {% if data.piece._author %}
       <h5 class="tl fw1 bb">Author</h5>
       <div class="w-20 dib v-top pr3">


### PR DESCRIPTION
Adds Facebook Twitter and LinkedIn share buttons to each article page #9

Currently the links are hard coded. A potential solution to this would be to add the URI as a config variable and then pass it in to the templates [as a setting](http://apostrophecms.org/docs/tutorials/getting-started/settings.html).